### PR TITLE
Add create_attribute filter to prevent errors.

### DIFF
--- a/dist/filters/create_attribute.filter.php
+++ b/dist/filters/create_attribute.filter.php
@@ -1,0 +1,5 @@
+<?php
+
+$filter = new Twig_SimpleFilter('create_attribute', function ($string) {
+  return $string;
+});


### PR DESCRIPTION
 i know I know, this doesn't do anything. The problem is that right now, even if I make sure the pattern lab side will never actually hit this filter, its presence causes an error. 