### PR TITLE
Added attach_library filter to prevent errors

### DIFF
--- a/dist/functions/attach_library.function.php
+++ b/dist/functions/attach_library.function.php
@@ -1,0 +1,5 @@
+<?php
+
+$function = new Twig_SimpleFunction('attach_library', function ($string) {
+  return;
+});


### PR DESCRIPTION
Probably a fair argument that attach_library doesn't belong in your patterns in the first place, but if you find yourself in that position for some reason it would be nice if Pattern Lab didn't error when encountering the filter.