### PR TITLE
Creates add_attribute twig function

### DIFF
--- a/dist/functions/create_attribute.function.php
+++ b/dist/functions/create_attribute.function.php
@@ -3,9 +3,8 @@
 $function = new Twig_SimpleFunction(
   'create_attribute',
   function ($attributes = []) {
-    if (isset($attributes) && isset($attributes['class'])) {
-      $classes = join(' ', $attributes['class']);
-      return ' class="' . $classes .'"';
+    foreach ($attributes as $key => $value) {
+      print ' ' . $key . '="' . join(' ', $value) . '"';
     }
   },
   array('is_safe' => array('html'))

--- a/dist/functions/create_attribute.function.php
+++ b/dist/functions/create_attribute.function.php
@@ -1,0 +1,12 @@
+<?php
+
+$function = new Twig_SimpleFunction(
+  'create_attribute',
+  function ($attributes = []) {
+    if (isset($attributes) && isset($attributes['class'])) {
+      $classes = join(' ', $attributes['class']);
+      return ' class="' . $classes .'"';
+    }
+  },
+  array('is_safe' => array('html'))
+);


### PR DESCRIPTION
Replicates the Drupal twig function create_attribute for patternlab
https://www.drupal.org/docs/8/theming/twig/functions-in-twig-templates#create_attribute

#8 got me thinking about this, so used existing `link` twig function to make `create_attribute` work in Pattern Lab.
Tested locally with:
```twig
<p{{ create_attribute({'class': ['paragraph', 'text']}) }}>{{ content }}</p>
``` 
which results in generated html: 
```html
<p class="paragraph text">Test paragraph content</p>
```